### PR TITLE
Update doc and tutorial on data loading

### DIFF
--- a/docs/data-formats.md
+++ b/docs/data-formats.md
@@ -34,4 +34,8 @@ COOL requires two additional files besides the csv file that contains raw data.
 * table.yaml: a yaml file that specifies the schema
 * dimension.csv: a csv file that specifies the value range of each dimension
 
-COOL [CSV LocalLoader](https://github.com/COOL-cohort/COOL/blob/main/src/main/java/com/nus/cool/loader/LocalLoader.java) takes these information to parse the csv data and create indexes. Please refer to [CSV Tutorial](tutorials/tutorial-csv.md) for a complete example.
+COOL [CSV LocalLoader](https://github.com/COOL-cohort/COOL/blob/main/src/main/java/com/nus/cool/loader/LocalLoader.java) takes these information to parse the csv data and create indexes. Please refer to [Tutorial](tutorials/tutorial-csv.md) for a complete example.
+
+## Parquet
+Similar to the CSV format support, COOL requires a yaml file that specifies the schema and a dimension file. To use the Parquet loader, the parquet-extensions module is needed. 
+Pass the ParquetDataLoaderConfig as the DataLoaderConfig to DataLoader builder, so that the DataLoader can process raw data stored parquet files. Please refer to [Parquet Tutorial](tutorial/tutorial-parquet.md) for a complete example.

--- a/docs/tutorials/tutorial-csv.md
+++ b/docs/tutorials/tutorial-csv.md
@@ -7,14 +7,14 @@ This tutorials shows a complete example of using a local COOL package to load th
 
 After building the COOL system, under the root directory, execute the following command will ingest the sogamo dataset to COOL system.
 ```bash
-java -cp ./target/cool-0.1-SNAPSHOT.jar com.nus.cool.loader.LocalLoader sogamo sogamo/table.yaml sogamo/dim_test.csv sogamo/test.csv ./test 65536
+java -jar cool-examples/load-csv/target/load-csv-0.1-SNAPSHOT.jar sogamo sogamo/table.yaml sogamo/dim_test.csv sogamo/test.csv ./test
 ```
 The command indicates that we use the LocalLoader to load the sogamo dataset. 
 * `sogamo`: name of the dataset
 * `sogamo/table.yaml`: the table.yaml describing the table schema
 * `sogamo/dim_test.csv`: the dimension file 
+* `sogamo/test.csv`: the raw data in csv format
 * `test`: the output directory to store the converted dataset 
-*  65536 (i.e. 64KB) chunk size for COOL [cublet](../data-formats.md)
 
 A directory named `test` appears containing the converted dataset. It contains one table named sogamo and the table has one cublet.
 ```

--- a/docs/tutorials/tutorial-parquet.md
+++ b/docs/tutorials/tutorial-parquet.md
@@ -1,0 +1,13 @@
+This tutorials shows a complete example of loading raw data in parquet format with COOL DataLoader. It is based on the sample sogamo csv dataset as the csv tutorial.
+
+The sample code can be found under cool-examples/load-parquet. Besides cool-core, this tutorials also assumes that the parquet-extensions and the load-parquet example are compiled and packaged.
+Under the root directory, execute the following command will create a parquet file with the first three entries in sogamo dataset and then loaded it to COOL system.
+```bash
+java -jar cool-examples/load-parquet/target/load-parquet-0.1-SNAPSHOT.jar sogamo sogamo/table.yaml sogamo/dim_test.csv sogamo/test.parquet ./test
+```
+The command arguments provides the table schema and dimension description for processing tuples loaded from parquet file and generate the native cool data files. 
+* `sogamo`: name of the dataset
+* `sogamo/table.yaml`: the table.yaml describing the table schema
+* `sogamo/dim_test.csv`: the dimension file 
+* `sogamo/test.parquet`: the raw data in parquet format
+* `test`: the output directory to store the converted dataset 


### PR DESCRIPTION
This PR updates the documentation of data-format and adds an additional tutorial page for parquet loader that resembles the one for csv loader. There are also changes w.r.t. the changes in COOL repo, for example, now we do not expose the chunk size in loading examples.